### PR TITLE
fix upload empty file bug

### DIFF
--- a/upyun/rest.py
+++ b/upyun/rest.py
@@ -156,6 +156,10 @@ class UpYunRest(object):
         elif hasattr(value, 'fileno'):
             length = get_fileobj_size(value)
             headers['Content-Length'] = length
+            # [ugly]:compatible with newest requests feature
+            # force the stream upload with empty file to normal upload
+            if not length:
+                value = ''
         elif value is not None:
             raise UpYunClientException('object type error')
 


### PR DESCRIPTION
when we using `requests>=2.9.0` to PUT an empty file, the `headers[Transfer-Encoding]` will be forced set to `chunked`, which is not support on "upyun.com". We have to make some ugly change to compatible the newest requests version.