### PR TITLE
file md5

### DIFF
--- a/upyun/resume.py
+++ b/upyun/resume.py
@@ -249,7 +249,7 @@ class UpYunResume(object):
         self.rest = rest
         self.f = f
         self.file_size = file_size
-        self.file_md5 = self.make_md5()
+        self.file_md5 = self.make_md5() if checksum else ""
         self.trace = ResumeTrace(self.rest.bucket, key, f.name, self.file_md5,
                                  file_size, store)
         self.headers = headers or {}


### PR DESCRIPTION
大文件计算 md5 比较耗时, checksum 没有指定时, 本地不检查断点之后, 续传文件的 md5 值是否一致