### PR TITLE
ignore E501 line too long error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 	@echo $(TAG)Running tests$(END)
 	wget http://zj-files.b0.upaiyun.com/python_sdk/mid.mp4 -O /tmp/test.mp4
 	pip install pytest pytest-cov flake8 tornado
-	flake8 upyun tests --ignore=E402,E226
+	flake8 upyun tests --ignore=E402,E226,E501
 	python examples/auth_server.py > /dev/null 2>&1 &
 	py.test --cov ./upyun --cov ./tests --verbose ./tests
 	ps aux | grep 'auth_server.py' | grep -v grep | awk '{print $$2}' | xargs kill -9


### PR DESCRIPTION
Now, CI failed due to E501 line too long

```
flake8 upyun tests --ignore=E402,E226
upyun/rest.py:148:80: E501 line too long (85 > 79 characters)
upyun/rest.py:230:80: E501 line too long (89 > 79 characters)
upyun/rest.py:235:80: E501 line too long (96 > 79 characters)
upyun/rest.py:262:80: E501 line too long (81 > 79 characters
``` 
From: https://travis-ci.org/upyun/python-sdk/jobs/330186541

So, why don't we fix it by ignoring E501