### PR TITLE
Feature/stream fileobject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ init: uninstall-upyun
 test:
 	@echo $(TAG)Running tests$(END)
 	wget http://zj-files.b0.upaiyun.com/python_sdk/mid.mp4 -O /tmp/test.mp4
-	pip install pytest pytest-cov flake8 tornado
+	pip install --upgrade pytest pytest-cov flake8 tornado
 	flake8 upyun tests --ignore=E402,E226
 	python examples/auth_server.py > /dev/null 2>&1 &
 	py.test --cov ./upyun --cov ./tests --verbose ./tests

--- a/upyun/modules/httpipe.py
+++ b/upyun/modules/httpipe.py
@@ -64,7 +64,7 @@ class UpYunHttp(object):
                 request_id = 'Unknown'
             status = resp.status_code
             if status // 100 != 2:
-                msg = resp.reason
+                msg = resp.reason or "Unknown"
                 err = resp.text
                 headers = resp.headers.items()
 


### PR DESCRIPTION
- feature: 支持 [requests res.raw](http://docs.python-requests.org/en/master/user/quickstart/#raw-response-content) 流式类文件对象作为 body。requests 该 stream file object 由 `urllib3` 库实现，所以，类似的 stream file object 都支持。
- bugfix: 修复 429 等 HTTP Reason 为空的非正常响应体无法按预期抛出 `UpYunServiceException` 异常的问题。
- test: 修复 429 too many requests 导致的测试问题以及新增 stream file object 测试用例。

> stream file object 示例，对一些远程大文件转存的场景比较方便，并且无需进行多余的磁盘缓冲：

```
res = requests.get("http://httpbin.org/image/jpeg", stream=True)
up.put('/test.jpeg', res.raw)
```
